### PR TITLE
AWS ECS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ go get go.opencensus.io/exporter/aws
 - [x] ~~Publish spans in a separate goroutine~~
 - [x] ~~Support propagation of http spans~~
 - [x] ~~Support remote spans~~
-- [ ] Test distributed spans
+- [x] ~~Verified works with ELB/ALB~~
 - [x] ~~Report errors / exceptions~~
 - [x] ~~Publish partial segments; currently only completed segments are published to aws~~
 

--- a/examples/xray/main.go
+++ b/examples/xray/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"os"
 
-	"go.opencensus.io/exporter/aws"
+	"github.com/census-instrumentation/opencensus-go-exporter-aws"
 	"go.opencensus.io/trace"
 )
 

--- a/http_test.go
+++ b/http_test.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/aws/aws-sdk-go/service/xray/xrayiface"
-	"go.opencensus.io/exporter/aws"
+	"github.com/census-instrumentation/opencensus-go-exporter-aws"
 	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/trace"
 )


### PR DESCRIPTION
Verified trace successfully captured from container hosted on AWS ECS instance using role based authentication.  

Added support for reading aws region from aws metadata urls.  In a default ECS deployment using role based authentication, neither AWS_DEFAULT_REGION nor AWS_REGION will be set.