### PR TITLE
Rename MakeXXXID to ConvertToXXXID

### DIFF
--- a/http_propagation.go
+++ b/http_propagation.go
@@ -107,8 +107,8 @@ func (f *HTTPFormat) SpanContextFromRequest(req *http.Request) (sc trace.SpanCon
 func (f *HTTPFormat) SpanContextToRequest(sc trace.SpanContext, req *http.Request) {
 	var (
 		header        = make([]byte, 0, 64)
-		amazonTraceID = MakeAmazonTraceID(sc.TraceID)
-		amazonSpanID  = MakeAmazonSpanID(sc.SpanID)
+		amazonTraceID = ConvertToAmazonTraceID(sc.TraceID)
+		amazonSpanID  = ConvertToAmazonSpanID(sc.SpanID)
 	)
 
 	header = append(header, prefixRoot...)

--- a/http_propagation_test.go
+++ b/http_propagation_test.go
@@ -39,10 +39,8 @@ func TestSpanContextFromRequest(t *testing.T) {
 	})
 
 	t.Run("traceID only", func(t *testing.T) {
-		var (
-			req           = httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-			amazonTraceID = MakeAmazonTraceID(traceID)
-		)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
+		amazonTraceID := ConvertToAmazonTraceID(traceID)
 		req.Header.Set(httpHeader, amazonTraceID)
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -61,10 +59,8 @@ func TestSpanContextFromRequest(t *testing.T) {
 	})
 
 	t.Run("traceID only with root prefix", func(t *testing.T) {
-		var (
-			req           = httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-			amazonTraceID = MakeAmazonTraceID(traceID)
-		)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
+		amazonTraceID := ConvertToAmazonTraceID(traceID)
 		req.Header.Set(httpHeader, header.RootPrefix+amazonTraceID)
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -83,11 +79,9 @@ func TestSpanContextFromRequest(t *testing.T) {
 	})
 
 	t.Run("traceID with parentSpanID", func(t *testing.T) {
-		var (
-			req           = httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-			amazonTraceID = MakeAmazonTraceID(traceID)
-			amazonSpanID  = MakeAmazonSpanID(spanID)
-		)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
+		amazonTraceID := ConvertToAmazonTraceID(traceID)
+		amazonSpanID := ConvertToAmazonSpanID(spanID)
 		req.Header.Set(httpHeader, prefixRoot+amazonTraceID+";"+prefixParent+amazonSpanID)
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -106,11 +100,9 @@ func TestSpanContextFromRequest(t *testing.T) {
 	})
 
 	t.Run("traceID with parentSpanID and sampled", func(t *testing.T) {
-		var (
-			req           = httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-			amazonTraceID = MakeAmazonTraceID(traceID)
-			amazonSpanID  = MakeAmazonSpanID(spanID)
-		)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
+		amazonTraceID := ConvertToAmazonTraceID(traceID)
+		amazonSpanID := ConvertToAmazonSpanID(spanID)
 		req.Header.Set(httpHeader, prefixRoot+amazonTraceID+";"+prefixParent+amazonSpanID+";"+prefixSampled+"1")
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -141,10 +133,8 @@ func TestSpanContextFromRequest(t *testing.T) {
 	})
 
 	t.Run("bad spanID", func(t *testing.T) {
-		var (
-			req           = httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-			amazonTraceID = MakeAmazonTraceID(traceID)
-		)
+		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
+		amazonTraceID := ConvertToAmazonTraceID(traceID)
 		req.Header.Set(httpHeader, prefixRoot+amazonTraceID+";"+prefixParent+"junk-span")
 
 		_, ok := format.SpanContextFromRequest(req)

--- a/http_test.go
+++ b/http_test.go
@@ -64,12 +64,11 @@ func TestHttp(t *testing.T) {
 		Handler:     handle("web"),
 	}
 
-	var (
-		traceID       = trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
-		amazonTraceID = aws.MakeAmazonTraceID(traceID)
-		req, _        = http.NewRequest(http.MethodGet, "http://www.example.com/index", strings.NewReader("hello"))
-		w             = httptest.NewRecorder()
-	)
+	traceID := trace.TraceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	amazonTraceID := aws.ConvertToAmazonTraceID(traceID)
+	req, _ := http.NewRequest(http.MethodGet, "http://www.example.com/index", strings.NewReader("hello"))
+
+	w := httptest.NewRecorder()
 	req.Header.Set(`X-Amzn-Trace-Id`, amazonTraceID)
 	req.Header.Set(`User-Agent`, "ua")
 

--- a/segment.go
+++ b/segment.go
@@ -153,7 +153,9 @@ type service struct {
 	Version string `json:"version,omitempty"`
 }
 
-// MakeTraceID – A unique identifier that connects all segments and subsegments
+// ConvertToAmazonTraceID converts a trace ID to the Amazon format.
+//
+// A trace ID unique identifier that connects all segments and subsegments
 // originating from a single client request.
 //  * A trace_id consists of three numbers separated by hyphens. For example,
 //    1-58406520-a006649127e371903a2de979. This includes:
@@ -162,7 +164,7 @@ type service struct {
 //  * For example, 10:00AM December 2nd, 2016 PST in epoch time is 1480615200 seconds,
 //    or 58406520 in hexadecimal.
 //  * A 96-bit identifier for the trace, globally unique, in 24 hexadecimal digits.
-func MakeAmazonTraceID(traceID trace.TraceID) string {
+func ConvertToAmazonTraceID(traceID trace.TraceID) string {
 	const (
 		// maxAge of 28 days.  AWS has a 30 day limit, let's be conservative rather than
 		// hit the limit
@@ -225,9 +227,9 @@ func ParseAmazonTraceID(t string) (trace.TraceID, error) {
 	return traceID, nil
 }
 
-// MakeAmazonSpanID generates an amazon spanID from a trace.SpanID - a 64-bit identifier
+// ConvertToAmazonSpanID generates an Amazon spanID from a trace.SpanID - a 64-bit identifier
 // for the segment, unique among segments in the same trace, in 16 hexadecimal digits.
-func MakeAmazonSpanID(v trace.SpanID) string {
+func ConvertToAmazonSpanID(v trace.SpanID) string {
 	if v == zeroSpanID {
 		return ""
 	}
@@ -343,7 +345,7 @@ func fixSegmentName(name string) string {
 
 func rawSegment(span *trace.SpanData) segment {
 	var (
-		traceID                 = MakeAmazonTraceID(span.TraceID)
+		traceID                 = ConvertToAmazonTraceID(span.TraceID)
 		startMicros             = span.StartTime.UnixNano() / int64(time.Microsecond)
 		startTime               = float64(startMicros) / 1e6
 		endMicros               = span.EndTime.UnixNano() / int64(time.Microsecond)
@@ -363,13 +365,13 @@ func rawSegment(span *trace.SpanData) segment {
 	}
 
 	return segment{
-		ID:          MakeAmazonSpanID(span.SpanID),
+		ID:          ConvertToAmazonSpanID(span.SpanID),
 		TraceID:     traceID,
 		Name:        name,
 		StartTime:   startTime,
 		EndTime:     endTime,
 		Namespace:   namespace,
-		ParentID:    MakeAmazonSpanID(span.ParentSpanID),
+		ParentID:    ConvertToAmazonSpanID(span.ParentSpanID),
 		Annotations: annotations,
 		Http:        http,
 		Error:       isError,

--- a/segment_test.go
+++ b/segment_test.go
@@ -26,17 +26,15 @@ import (
 )
 
 func BenchmarkSerializeSegment(t *testing.B) {
-	var (
-		w       = bytes.NewBuffer(make([]byte, 0, 2048))
-		encoder = json.NewEncoder(w)
-		s       = segment{
-			Name:      "example.com",
-			ID:        "70de5b6f19ff9a0a",
-			TraceID:   "1-581cf771-a006649127e371903a2de979",
-			StartTime: 1.478293361271E9,
-			EndTime:   1.478293361449E9,
-		}
-	)
+	w := bytes.NewBuffer(make([]byte, 0, 2048))
+	encoder := json.NewEncoder(w)
+	s := segment{
+		Name:      "example.com",
+		ID:        "70de5b6f19ff9a0a",
+		TraceID:   "1-581cf771-a006649127e371903a2de979",
+		StartTime: 1.478293361271E9,
+		EndTime:   1.478293361449E9,
+	}
 
 	for i := 0; i < t.N; i++ {
 		w.Reset()
@@ -48,11 +46,9 @@ func BenchmarkSerializeSegment(t *testing.B) {
 
 func TestMakeID(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
-		var (
-			spanID   = trace.SpanID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
-			expected = "0102030405060708"
-			id       = MakeAmazonSpanID(spanID)
-		)
+		spanID := trace.SpanID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
+		expected := "0102030405060708"
+		id := ConvertToAmazonSpanID(spanID)
 
 		if id != expected {
 			t.Errorf("got %v; want %v", id, expected)
@@ -60,11 +56,9 @@ func TestMakeID(t *testing.T) {
 	})
 
 	t.Run("zero", func(t *testing.T) {
-		var (
-			spanID   = trace.SpanID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
-			expected = ""
-			id       = MakeAmazonSpanID(spanID)
-		)
+		spanID := trace.SpanID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
+		expected := ""
+		id := ConvertToAmazonSpanID(spanID)
 
 		if id != expected {
 			t.Errorf("got %v; want %v", id, expected)
@@ -74,10 +68,8 @@ func TestMakeID(t *testing.T) {
 
 func TestMakeTraceID(t *testing.T) {
 	t.Run("epoch out of range", func(t *testing.T) {
-		var (
-			traceID       = trace.TraceID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10}
-			amazonTraceID = MakeAmazonTraceID(traceID)
-		)
+		traceID := trace.TraceID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10}
+		amazonTraceID := ConvertToAmazonTraceID(traceID)
 
 		parsedID, err := ParseAmazonTraceID(amazonTraceID)
 		if err != nil {
@@ -102,10 +94,8 @@ func TestMakeTraceID(t *testing.T) {
 }
 
 func TestParseAmazonTraceID(t *testing.T) {
-	var (
-		input    = "1-5759e988-05060708090a0b0c0d0e0f10"
-		expected = trace.TraceID{0x57, 0x59, 0xe9, 0x88, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10}
-	)
+	input := "1-5759e988-05060708090a0b0c0d0e0f10"
+	expected := trace.TraceID{0x57, 0x59, 0xe9, 0x88, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10}
 
 	traceID, err := ParseAmazonTraceID(input)
 	if err != nil {
@@ -123,10 +113,8 @@ func TestParseAmazonTraceID(t *testing.T) {
 }
 
 func TestParseAmazonSpanID(t *testing.T) {
-	var (
-		input    = "53995c3f42cd8ad8"
-		expected = trace.SpanID{0x53, 0x99, 0x5c, 0x3f, 0x42, 0xcd, 0x8a, 0xd8}
-	)
+	input := "53995c3f42cd8ad8"
+	expected := trace.SpanID{0x53, 0x99, 0x5c, 0x3f, 0x42, 0xcd, 0x8a, 0xd8}
 
 	spanID, err := ParseAmazonSpanID(input)
 	if err != nil {

--- a/xray_test.go
+++ b/xray_test.go
@@ -68,12 +68,12 @@ func TestLiveExporter(t *testing.T) {
 	trace.SetDefaultSampler(trace.AlwaysSample())
 
 	attributes := []trace.Attribute{
-		trace.StringAttribute{Key: "key", Value: "value"},
+		trace.StringAttribute("key", "value"),
 	}
 
 	ctx, parent := trace.StartSpan(context.Background(), "parent")
 	parent.Annotate(attributes, "did the thing")
-	parent.SetAttributes(trace.StringAttribute{Key: "hello", Value: "world"})
+	parent.AddAttributes(trace.StringAttribute("hello", "world"))
 
 	time.Sleep(75 * time.Millisecond)
 	_, child := trace.StartSpan(ctx, "child")
@@ -248,6 +248,10 @@ func TestExporter(t *testing.T) {
 }
 
 func TestOptions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping test in short mode")
+	}
+
 	t.Run("SetOutput", func(t *testing.T) {
 		var output = os.Stderr
 		config, err := buildConfig(WithOutput(output))


### PR DESCRIPTION
Make prefix is used for allocators, such as a map allocator.

Also fix the broken build.