### PR TITLE
Provide header parser and span context converter

### DIFF
--- a/examples/xray/main.go
+++ b/examples/xray/main.go
@@ -53,7 +53,9 @@ func main() {
 	trace.RegisterExporter(exporter)
 
 	// For demoing purposes, always sample.
-	trace.SetDefaultSampler(trace.AlwaysSample())
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
 
 	ctx, span := trace.StartSpan(ctx, "/foo")
 	bar(ctx)

--- a/http_propagation_test.go
+++ b/http_propagation_test.go
@@ -47,7 +47,7 @@ func TestSpanContextFromRequest(t *testing.T) {
 
 	t.Run("traceID only", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-		amazonTraceID := ConvertToAmazonTraceID(traceID)
+		amazonTraceID := convertToAmazonTraceID(traceID)
 		req.Header.Set(httpHeader, amazonTraceID)
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -67,7 +67,7 @@ func TestSpanContextFromRequest(t *testing.T) {
 
 	t.Run("traceID only with root prefix", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-		amazonTraceID := ConvertToAmazonTraceID(traceID)
+		amazonTraceID := convertToAmazonTraceID(traceID)
 		req.Header.Set(httpHeader, header.RootPrefix+amazonTraceID)
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -87,8 +87,8 @@ func TestSpanContextFromRequest(t *testing.T) {
 
 	t.Run("traceID with parentSpanID", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-		amazonTraceID := ConvertToAmazonTraceID(traceID)
-		amazonSpanID := ConvertToAmazonSpanID(spanID)
+		amazonTraceID := convertToAmazonTraceID(traceID)
+		amazonSpanID := convertToAmazonSpanID(spanID)
 		req.Header.Set(httpHeader, prefixRoot+amazonTraceID+";"+prefixParent+amazonSpanID)
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -108,8 +108,8 @@ func TestSpanContextFromRequest(t *testing.T) {
 
 	t.Run("traceID with parentSpanID and sampled", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-		amazonTraceID := ConvertToAmazonTraceID(traceID)
-		amazonSpanID := ConvertToAmazonSpanID(spanID)
+		amazonTraceID := convertToAmazonTraceID(traceID)
+		amazonSpanID := convertToAmazonSpanID(spanID)
 		req.Header.Set(httpHeader, prefixRoot+amazonTraceID+";"+prefixParent+amazonSpanID+";"+prefixSampled+"1")
 
 		sc, ok := format.SpanContextFromRequest(req)
@@ -141,7 +141,7 @@ func TestSpanContextFromRequest(t *testing.T) {
 
 	t.Run("bad spanID", func(t *testing.T) {
 		req := httptest.NewRequest(http.MethodGet, "http://localhost/", nil)
-		amazonTraceID := ConvertToAmazonTraceID(traceID)
+		amazonTraceID := convertToAmazonTraceID(traceID)
 		req.Header.Set(httpHeader, prefixRoot+amazonTraceID+";"+prefixParent+"junk-span")
 
 		_, ok := format.SpanContextFromRequest(req)

--- a/segment_test.go
+++ b/segment_test.go
@@ -48,7 +48,7 @@ func TestMakeID(t *testing.T) {
 	t.Run("ok", func(t *testing.T) {
 		spanID := trace.SpanID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8}
 		expected := "0102030405060708"
-		id := ConvertToAmazonSpanID(spanID)
+		id := convertToAmazonSpanID(spanID)
 
 		if id != expected {
 			t.Errorf("got %v; want %v", id, expected)
@@ -58,7 +58,7 @@ func TestMakeID(t *testing.T) {
 	t.Run("zero", func(t *testing.T) {
 		spanID := trace.SpanID{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
 		expected := ""
-		id := ConvertToAmazonSpanID(spanID)
+		id := convertToAmazonSpanID(spanID)
 
 		if id != expected {
 			t.Errorf("got %v; want %v", id, expected)
@@ -69,9 +69,9 @@ func TestMakeID(t *testing.T) {
 func TestMakeTraceID(t *testing.T) {
 	t.Run("epoch out of range", func(t *testing.T) {
 		traceID := trace.TraceID{0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10}
-		amazonTraceID := ConvertToAmazonTraceID(traceID)
+		amazonTraceID := convertToAmazonTraceID(traceID)
 
-		parsedID, err := ParseAmazonTraceID(amazonTraceID)
+		parsedID, err := parseAmazonTraceID(amazonTraceID)
 		if err != nil {
 			t.Fatalf("got %v; want nil", err)
 		}
@@ -97,7 +97,7 @@ func TestParseAmazonTraceID(t *testing.T) {
 	input := "1-5759e988-05060708090a0b0c0d0e0f10"
 	expected := trace.TraceID{0x57, 0x59, 0xe9, 0x88, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x10}
 
-	traceID, err := ParseAmazonTraceID(input)
+	traceID, err := parseAmazonTraceID(input)
 	if err != nil {
 		t.Fatalf("expected nil; got %v", err)
 	}
@@ -116,7 +116,7 @@ func TestParseAmazonSpanID(t *testing.T) {
 	input := "53995c3f42cd8ad8"
 	expected := trace.SpanID{0x53, 0x99, 0x5c, 0x3f, 0x42, 0xcd, 0x8a, 0xd8}
 
-	spanID, err := ParseAmazonSpanID(input)
+	spanID, err := parseAmazonSpanID(input)
 	if err != nil {
 		t.Fatalf("expected true; got false")
 	}

--- a/xray_test.go
+++ b/xray_test.go
@@ -65,7 +65,9 @@ func TestLiveExporter(t *testing.T) {
 	}
 
 	trace.RegisterExporter(exporter)
-	trace.SetDefaultSampler(trace.AlwaysSample())
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
 
 	attributes := []trace.Attribute{
 		trace.StringAttribute("key", "value"),
@@ -118,7 +120,9 @@ func TestLiveLargeNumberOfSpans(t *testing.T) {
 	}
 
 	trace.RegisterExporter(exporter)
-	trace.SetDefaultSampler(trace.AlwaysSample())
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
 
 	makeSpan(context.Background(), 100) // deep span
 	makeSpan(context.Background(), 1)   // shallow span to force new call to onExport
@@ -128,18 +132,18 @@ func TestLiveLargeNumberOfSpans(t *testing.T) {
 	<-published
 }
 
-type mockSegments struct {
+type testSegments struct {
 	xrayiface.XRayAPI
 	ch chan segment
 }
 
-func (m *mockSegments) PutTraceSegments(in *xray.PutTraceSegmentsInput) (*xray.PutTraceSegmentsOutput, error) {
+func (t *testSegments) PutTraceSegments(in *xray.PutTraceSegmentsInput) (*xray.PutTraceSegmentsOutput, error) {
 	for _, doc := range in.TraceSegmentDocuments {
 		var s segment
 		if err := json.Unmarshal([]byte(*doc), &s); err != nil {
 			return nil, err
 		}
-		m.ch <- s
+		t.ch <- s
 	}
 	return nil, nil
 }
@@ -212,7 +216,7 @@ func TestExporter(t *testing.T) {
 
 			// Given
 			var (
-				api     = &mockSegments{ch: make(chan segment, 16)}
+				api     = &testSegments{ch: make(chan segment, 16)}
 				content struct {
 					Input    spec
 					Expected []segment
@@ -228,7 +232,9 @@ func TestExporter(t *testing.T) {
 				t.Fatalf("expected to create exporter; got %v", err)
 			}
 			trace.RegisterExporter(exporter)
-			trace.SetDefaultSampler(trace.AlwaysSample())
+			trace.ApplyConfig(trace.Config{
+				DefaultSampler: trace.AlwaysSample(),
+			})
 
 			// When - we create a span structure
 			walk(context.Background(), content.Input)
@@ -317,7 +323,7 @@ func TestOptions(t *testing.T) {
 			version  = "blah"
 			origin   = OriginEB
 			exported = make(chan struct{})
-			api      = &mockSegments{ch: make(chan segment, 1)}
+			api      = &testSegments{ch: make(chan segment, 1)}
 			onExport = func(export OnExport) {
 				select {
 				case <-exported:
@@ -337,7 +343,9 @@ func TestOptions(t *testing.T) {
 		buildConfig()
 
 		trace.RegisterExporter(exporter)
-		trace.SetDefaultSampler(trace.AlwaysSample())
+		trace.ApplyConfig(trace.Config{
+			DefaultSampler: trace.AlwaysSample(),
+		})
 
 		// When
 		_, span := trace.StartSpan(context.Background(), "span")
@@ -368,12 +376,14 @@ func TestOptions(t *testing.T) {
 
 func TestSetBufferSizeTrigger(t *testing.T) {
 	var (
-		api         = &mockSegments{ch: make(chan segment, 1)}
+		api         = &testSegments{ch: make(chan segment, 1)}
 		exporter, _ = NewExporter(WithAPI(api), WithBufferSize(1))
 	)
 
 	trace.RegisterExporter(exporter)
-	trace.SetDefaultSampler(trace.AlwaysSample())
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
 
 	// When
 	_, span := trace.StartSpan(context.Background(), "span")
@@ -389,12 +399,14 @@ func TestSetBufferSizeTrigger(t *testing.T) {
 
 func TestFlush(t *testing.T) {
 	var (
-		api         = &mockSegments{ch: make(chan segment, 1)}
+		api         = &testSegments{ch: make(chan segment, 1)}
 		exporter, _ = NewExporter(WithAPI(api))
 	)
 
 	trace.RegisterExporter(exporter)
-	trace.SetDefaultSampler(trace.AlwaysSample())
+	trace.ApplyConfig(trace.Config{
+		DefaultSampler: trace.AlwaysSample(),
+	})
 
 	_, span := trace.StartSpan(context.Background(), "span")
 	span.End()
@@ -413,12 +425,14 @@ func TestFlush(t *testing.T) {
 func TestClose(t *testing.T) {
 	t.Run("flushes buffer", func(t *testing.T) {
 		var (
-			api         = &mockSegments{ch: make(chan segment, 1)}
+			api         = &testSegments{ch: make(chan segment, 1)}
 			exporter, _ = NewExporter(WithAPI(api))
 		)
 
 		trace.RegisterExporter(exporter)
-		trace.SetDefaultSampler(trace.AlwaysSample())
+		trace.ApplyConfig(trace.Config{
+			DefaultSampler: trace.AlwaysSample(),
+		})
 
 		_, span := trace.StartSpan(context.Background(), "span")
 		span.End()
@@ -436,12 +450,14 @@ func TestClose(t *testing.T) {
 
 	t.Run("additional messages dropped after exporter is Closed", func(t *testing.T) {
 		var (
-			api         = &mockSegments{ch: make(chan segment, 1)}
+			api         = &testSegments{ch: make(chan segment, 1)}
 			exporter, _ = NewExporter(WithAPI(api))
 		)
 
 		trace.RegisterExporter(exporter)
-		trace.SetDefaultSampler(trace.AlwaysSample())
+		trace.ApplyConfig(trace.Config{
+			DefaultSampler: trace.AlwaysSample(),
+		})
 
 		// When
 		exporter.Close()


### PR DESCRIPTION
Users should never need the low-level traceID and spanID
parsing but the conversion between trace headers and
span context.