### PR TITLE
cleaned up tests to no longer require AWS_DEFAULT_REGION to be defined

### DIFF
--- a/xray_test.go
+++ b/xray_test.go
@@ -248,13 +248,9 @@ func TestExporter(t *testing.T) {
 }
 
 func TestOptions(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping test in short mode")
-	}
-
-	t.Run("SetOutput", func(t *testing.T) {
+	t.Run("WithOutput", func(t *testing.T) {
 		var output = os.Stderr
-		config, err := buildConfig(WithOutput(output))
+		config, err := buildConfig(WithOutput(output), WithRegion("blah"))
 		if err != nil {
 			t.Fatalf("want nil; got %v", err)
 		}
@@ -263,9 +259,9 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("SetInterval", func(t *testing.T) {
+	t.Run("WithInterval", func(t *testing.T) {
 		const interval = time.Minute
-		config, err := buildConfig(WithInterval(interval))
+		config, err := buildConfig(WithInterval(interval), WithRegion("blah"))
 		if err != nil {
 			t.Fatalf("want nil; got %v", err)
 		}
@@ -274,9 +270,9 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("SetBufferSize", func(t *testing.T) {
+	t.Run("WithBufferSize", func(t *testing.T) {
 		const bufferSize = 15
-		config, err := buildConfig(WithBufferSize(bufferSize))
+		config, err := buildConfig(WithBufferSize(bufferSize), WithRegion("blah"))
 		if err != nil {
 			t.Fatalf("want nil; got %v", err)
 		}
@@ -285,9 +281,9 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("SetVersion", func(t *testing.T) {
+	t.Run("WithVersion", func(t *testing.T) {
 		const version = "latest"
-		config, err := buildConfig(WithVersion(version))
+		config, err := buildConfig(WithVersion(version), WithRegion("blah"))
 		if err != nil {
 			t.Fatalf("want nil; got %v", err)
 		}
@@ -300,9 +296,9 @@ func TestOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("SetOrigin", func(t *testing.T) {
+	t.Run("WithOrigin", func(t *testing.T) {
 		const origin = OriginEB
-		config, err := buildConfig(WithOrigin(origin))
+		config, err := buildConfig(WithOrigin(origin), WithRegion("blah"))
 		if err != nil {
 			t.Fatalf("want nil; got %v", err)
 		}


### PR DESCRIPTION
Resolves issue #13 by explicitly defining aws region via WithRegion